### PR TITLE
Use platform-independent file open for PDF preview

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,15 @@ from reportlab.pdfgen import canvas
 import argparse
 import subprocess as proc
 import sys
+import os
+
+# https://stackoverflow.com/questions/17317219/is-there-an-platform-independent-equivalent-of-os-startfile
+def open_file(filename):
+    if sys.platform == "win32":
+        os.startfile(filename)
+    else:
+        opener ="open" if sys.platform == "darwin" else "xdg-open"
+        proc.call([opener, filename])
 
 # setup command-line arguments
 parser = argparse.ArgumentParser("Print labels for dymo label writer, optionally with a qr code and an icon")
@@ -115,7 +124,7 @@ c.save()
 print("Wrote '%s'" % args.output)
 
 if args.preview:
-    proc.check_output(['xdg-open', args.output])
+    open_file(args.output)
 
 # print
 if args.print:


### PR DESCRIPTION
Automatically pick the pdf-preview command based on platform. 
Tested on Mac OSX.